### PR TITLE
Enable conditional display of devlog and portfolio

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -37,15 +37,11 @@
 <p>Hi, I'm Dongwook Lee — a passionate self-taught developer from South Korea. I love building games, automating systems, and exploring new ideas through code.</p>
 <h2>DevLog</h2>
 <ul>
-
-    <li><a href="/devlog/hello-world.html">Hello World</a> - 2025-07-12</li>
-
+<li><a href="/devlog/hello-world.html">Hello World</a> - 2025-07-12</li>
 </ul>
 <h2>Web Portfolio</h2>
 <ul>
-
-    <li><a href="/portfolio/cool-script.html">Cool Script</a></li>
-
+<li><a href="/portfolio/cool-script.html">Cool Script</a></li>
 </ul>
 
 <footer>

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,9 +29,7 @@
 </head>
 <body>
 <nav>
-    <a href="index.html">Home</a>
-    <a href="devlog/index.html">DevLog</a>
-    <a href="portfolio/index.html">Portfolio</a>
+    {{ nav_links }}
 </nav>
 {{ content }}
 <footer>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,14 +1,4 @@
 <h1>Dongwook Lee</h1>
 <p>Hi, I'm Dongwook Lee — a passionate self-taught developer from South Korea. I love building games, automating systems, and exploring new ideas through code.</p>
-<h2>DevLog</h2>
-<ul>
-{% for post in devlog %}
-    <li><a href="{{ post['link'] }}">{{ post['title'] }}</a> - {{ post['date'] }}</li>
-{% endfor %}
-</ul>
-<h2>Web Portfolio</h2>
-<ul>
-{% for prog in portfolio %}
-    <li><a href="{{ prog['link'] }}">{{ prog['title'] }}</a></li>
-{% endfor %}
-</ul>
+{{ devlog_section }}
+{{ portfolio_section }}


### PR DESCRIPTION
## Summary
- add `build_nav_links` helper to construct navigation bar dynamically
- only build DevLog and Portfolio sections and navigation if content exists
- update templates for new placeholders
- regenerate index with new logic

## Testing
- `python3 generate_site.py`

------
https://chatgpt.com/codex/tasks/task_e_6871ff6c0a44832bbffb2606e0e71255