### PR TITLE
Handle HTML-based portfolio entries

### DIFF
--- a/content/portfolio/cool-script.html
+++ b/content/portfolio/cool-script.html
@@ -1,39 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <base href="/CheeseV/">
-    <title>Cool Script</title>
-    <style>
-        body {
-            font-family: 'Roboto Mono', monospace;
-            margin: 2rem;
-            max-width: 900px;
-            background-color: #111;
-            color: #eee;
-        }
-        nav a {
-            margin-right: 1rem;
-            color: #0af;
-            text-decoration: none;
-        }
-        footer {
-            margin-top: 2rem;
-            font-size: 0.8rem;
-            color: #888;
-        }
-        a:hover {
-            text-decoration: underline;
-        }
-    </style>
-</head>
-<body>
-<nav>
-    <a href="index.html">Home</a>
-    <a href="devlog/index.html">DevLog</a>
-    <a href="portfolio/index.html">Portfolio</a>
-</nav>
-<h1>Cool Script</h1>
+<title>Cool Script</title>
 <style>
     #typewriter {
         font-size: 1.4rem;
@@ -84,9 +49,3 @@ function startTyping() {
     type();
 }
 </script>
-
-<footer>
-    <p>&copy; 2025 Jdeseech</p>
-</footer>
-</body>
-</html>

--- a/content/portfolio/cool-script.md
+++ b/content/portfolio/cool-script.md
@@ -1,3 +1,0 @@
-# Cool Script
-
-This program prints `Hello, GitHub Pages!` to the console.


### PR DESCRIPTION
## Summary
- support HTML content for portfolio generation
- update example portfolio page to HTML snippet

## Testing
- `python3 generate_site.py`

------
https://chatgpt.com/codex/tasks/task_e_687203857838832bae91da0fd6b70c5e