### PR TITLE
Adjust CheeseV popup hint styles

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -33,9 +33,10 @@
             color: #f0f;
         }
         #cheesev-hint {
-            font-size: 0.5em;
+            font-size: 0.4em;
             cursor: pointer;
             margin-left: 0.5rem;
+            color: #0cc;
         }
         #cheesev-popup {
             display: none;


### PR DESCRIPTION
## Summary
- shrink "What's CheeseV?" button size
- darken its color

## Testing
- `python3 generate_site.py`

------
https://chatgpt.com/codex/tasks/task_e_68723b8aa084832bbfa4875fc79a7205