### PR TITLE
Add gradient reveal intro

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,15 +1,37 @@
 <h1>CheeseV</h1>
 
-<p>
+<div id="intro">
     Hi, I'm Dongwook Lee — a self-taught developer based in South Korea.<br>
     I build tools, systems, and games from scratch, often starting with small ideas and shaping them through code.<br>
     My current interests include game development, automation, and systems programming. I learn best by making things.
-</p>
+</div>
 
 <p>
     You can find more of my work on
     <a href="https://github.com/cheesedongjin" target="_blank" rel="noopener noreferrer">GitHub</a>.
 </p>
+
+<style>
+    #intro {
+        font-size: 1rem;
+        white-space: pre-wrap;
+        position: relative;
+        min-height: 5.6rem;
+        font-family: 'Roboto Mono', monospace;
+        color: transparent;
+        background-image: linear-gradient(90deg, var(--primary-color), var(--primary-color));
+        background-size: 0% 100%;
+        background-clip: text;
+        -webkit-background-clip: text;
+        animation: revealText 2.5s forwards;
+    }
+
+    @keyframes revealText {
+        to {
+            background-size: 100% 100%;
+        }
+    }
+</style>
 
 {{ devlog_section }}
 {{ portfolio_section }}


### PR DESCRIPTION
## Summary
- create gradient reveal effect for the intro on the home page

## Testing
- `python -m py_compile generate_site.py`
- `python generate_site.py`

------
https://chatgpt.com/codex/tasks/task_e_68745dcd856c832b9945aa8a856ab60e