### PR TITLE
Display DevLog and Portfolio as tree

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -228,6 +228,48 @@
         #intro.revealed::after {
             display: none;
         }
+
+        /* Directory tree layout for main page */
+        .directory-tree,
+        .directory-tree ul {
+            list-style: none;
+            margin: 0;
+            padding-left: 1.2em;
+            position: relative;
+        }
+
+        .directory-tree li {
+            margin: 0;
+            padding-left: 0.8em;
+            position: relative;
+        }
+
+        .directory-tree li::before {
+            content: '';
+            position: absolute;
+            top: 0.8em;
+            left: -0.8em;
+            width: 0.8em;
+            border-top: 1px solid var(--primary-color);
+        }
+
+        .directory-tree li:not(:last-child)::after {
+            content: '';
+            position: absolute;
+            top: 0.8em;
+            bottom: 0;
+            left: -0.8em;
+            border-left: 1px solid var(--primary-color);
+        }
+
+        .directory-tree ul::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            border-left: 1px solid var(--primary-color);
+        }
     </style>
 </head>
 <body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,5 +10,11 @@
     <a href="https://github.com/cheesedongjin" target="_blank" rel="noopener noreferrer">GitHub</a>.
 </p>
 
-{{ devlog_section }}
-{{ portfolio_section }}
+<ul class="directory-tree">
+    <li>
+        {{ devlog_section }}
+    </li>
+    <li>
+        {{ portfolio_section }}
+    </li>
+</ul>


### PR DESCRIPTION
## Summary
- style DevLog and Web Portfolio lists as a directory tree
- wrap index sections in a root list so connecting lines render correctly
- refine CSS so connecting lines continue smoothly and stop after the last item

## Testing
- `pytest -q`
- `python3 generate_site.py`


------
https://chatgpt.com/codex/tasks/task_e_6875b5cfcc44832b8ccb633ecf21b0d3