### PR TITLE
Improve directory tree connectors

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -230,45 +230,29 @@
         }
 
         /* Directory tree layout for main page */
+        .directory-container {
+            position: relative;
+        }
+
         .directory-tree,
         .directory-tree ul {
             list-style: none;
             margin: 0;
             padding-left: 1.2em;
-            position: relative;
         }
 
         .directory-tree li {
             margin: 0;
             padding-left: 0.8em;
-            position: relative;
         }
 
-        .directory-tree li::before {
-            content: '';
-            position: absolute;
-            top: 0.8em;
-            left: -0.8em;
-            width: 0.8em;
-            border-top: 1px solid var(--primary-color);
-        }
-
-        .directory-tree li:not(:last-child)::after {
-            content: '';
-            position: absolute;
-            top: 0.8em;
-            bottom: 0;
-            left: -0.8em;
-            border-left: 1px solid var(--primary-color);
-        }
-
-        .directory-tree ul::before {
-            content: '';
+        #tree-lines {
             position: absolute;
             top: 0;
-            bottom: 0;
             left: 0;
-            border-left: 1px solid var(--primary-color);
+            width: 100%;
+            height: 100%;
+            pointer-events: none;
         }
     </style>
 </head>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,11 +10,63 @@
     <a href="https://github.com/cheesedongjin" target="_blank" rel="noopener noreferrer">GitHub</a>.
 </p>
 
-<ul class="directory-tree">
-    <li>
-        {{ devlog_section }}
-    </li>
-    <li>
-        {{ portfolio_section }}
-    </li>
-</ul>
+<div class="directory-container">
+    <svg id="tree-lines"></svg>
+    <ul class="directory-tree">
+        <li>
+            {{ devlog_section }}
+        </li>
+        <li>
+            {{ portfolio_section }}
+        </li>
+    </ul>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    const container = document.querySelector('.directory-container');
+    const tree = container.querySelector('.directory-tree');
+    const svg = container.querySelector('#tree-lines');
+    const NS = 'http://www.w3.org/2000/svg';
+
+    function addPath(d) {
+        const path = document.createElementNS(NS, 'path');
+        path.setAttribute('d', d);
+        path.setAttribute('stroke', 'var(--primary-color)');
+        path.setAttribute('fill', 'none');
+        svg.appendChild(path);
+    }
+
+    function connect(ul, rect, isRoot = false) {
+        const items = Array.from(ul.children).filter(el => el.tagName === 'LI');
+        if (!items.length) return;
+
+        const ulRect = ul.getBoundingClientRect();
+        const first = items[0].getBoundingClientRect();
+        const last = items[items.length - 1].getBoundingClientRect();
+        const x = ulRect.left - rect.left;
+        const startY = isRoot ? 0 : first.top - rect.top + first.height / 2;
+        const endY = last.top - rect.top + last.height / 2;
+        addPath(`M${x} ${startY}V${endY}`);
+
+        items.forEach(li => {
+            const lr = li.getBoundingClientRect();
+            const y = lr.top - rect.top + lr.height / 2;
+            const lx = lr.left - rect.left;
+            addPath(`M${x} ${y}H${lx}`);
+            li.querySelectorAll(':scope > ul').forEach(childUl => connect(childUl, rect));
+        });
+    }
+
+    function drawLines() {
+        svg.innerHTML = '';
+        const rect = container.getBoundingClientRect();
+        svg.setAttribute('width', rect.width);
+        svg.setAttribute('height', rect.height);
+        connect(tree, rect, true);
+    }
+
+    drawLines();
+    window.addEventListener('resize', drawLines);
+});
+</script>


### PR DESCRIPTION
## Summary
- draw vertical trunk lines and connector paths with SVG
- resize and redraw connectors on window resize
- extend connectors from a hidden root above `DevLog` and `Portfolio`

## Testing
- `python generate_site.py`


------
https://chatgpt.com/codex/tasks/task_e_6875b98a5ee8832b8a677d440bb63ce5