### PR TITLE
Fix devlog and portfolio page generation

### DIFF
--- a/generate_site.py
+++ b/generate_site.py
@@ -177,9 +177,9 @@ def build_devlog(nav_links):
                 nav_links=nav_links,
                 after_nav="",
             )
-            output_path = os.path.join(OUTPUT_DIR, 'devlog', slug)
+            output_path = os.path.join(OUTPUT_DIR, 'devlog', slug, 'index.html')
             write_file(output_path, page)
-            item = {'title': title, 'link': f'devlog/{slug}', 'date': date_str}
+            item = {'title': title, 'link': f'devlog/{slug}/', 'date': date_str}
             posts.append(item)
             cat = os.path.relpath(root, posts_dir)
             if cat == '.':
@@ -270,9 +270,9 @@ def build_portfolio(nav_links):
                 nav_links=nav_links,
                 after_nav="",
             )
-            output_path = os.path.join(OUTPUT_DIR, 'portfolio', slug)
+            output_path = os.path.join(OUTPUT_DIR, 'portfolio', slug, 'index.html')
             write_file(output_path, page)
-            item = {'title': title, 'link': f'portfolio/{slug}'}
+            item = {'title': title, 'link': f'portfolio/{slug}/'}
             programs.append(item)
             cat = os.path.relpath(root, programs_dir)
             if cat == '.':


### PR DESCRIPTION
## Summary
- fix path generation for devlog and portfolio pages so GitHub Pages finds them

## Testing
- `python3 generate_site.py`

------
https://chatgpt.com/codex/tasks/task_e_6875f30987e4832bb010abd48c664763