### PR TITLE
Fix missing after_nav variable

### DIFF
--- a/generate_site.py
+++ b/generate_site.py
@@ -202,6 +202,7 @@ def build_devlog(nav_links):
                 title=SITE_NAME + ' - ' + cat,
                 content=cat_list,
                 nav_links=nav_links,
+                after_nav="",
             )
             write_file(os.path.join(OUTPUT_DIR, 'devlog', cat, 'index.html'), cat_page)
         categories_content = '\n'.join(sections)
@@ -215,6 +216,7 @@ def build_devlog(nav_links):
             title=SITE_NAME + ' - ' + 'DevLog',
             content=list_content,
             nav_links=nav_links,
+            after_nav="",
         )
         write_file(os.path.join(OUTPUT_DIR, 'devlog', 'index.html'), list_page)
     return posts, posts_by_cat
@@ -291,6 +293,7 @@ def build_portfolio(nav_links):
                 title=SITE_NAME + ' - ' + cat,
                 content=cat_list,
                 nav_links=nav_links,
+                after_nav="",
             )
             write_file(os.path.join(OUTPUT_DIR, 'portfolio', cat, 'index.html'), cat_page)
         categories_content = '\n'.join(sections)
@@ -304,6 +307,7 @@ def build_portfolio(nav_links):
             title=SITE_NAME + ' - ' + 'Portfolio',
             content=list_content,
             nav_links=nav_links,
+            after_nav="",
         )
         write_file(os.path.join(OUTPUT_DIR, 'portfolio', 'index.html'), list_page)
     return programs, programs_by_cat


### PR DESCRIPTION
## Summary
- pass `after_nav` when rendering DevLog and Portfolio list pages

## Testing
- `python generate_site.py`

------
https://chatgpt.com/codex/tasks/task_e_6875f7cd0440832bba7f20245e3e2c19