### PR TITLE
Add 404 to sitemap

### DIFF
--- a/generate_site.py
+++ b/generate_site.py
@@ -483,7 +483,7 @@ def build_site():
     )
     write_file(os.path.join(OUTPUT_DIR, 'index.html'), index_page)
 
-    sitemap_entries = ['index.html']
+    sitemap_entries = ['index.html', '404.html']
     if posts:
         sitemap_entries.append('devlog/index.html')
         for cat in posts_by_cat:


### PR DESCRIPTION
## Summary
- update `generate_site.py` to ensure the `404.html` page is included when building `sitemap.xml`

## Testing
- `python generate_site.py`

------
https://chatgpt.com/codex/tasks/task_e_68786de6d680832b898ca4667f4d130c