### PR TITLE
Use style.css for devlog markdown

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1050,6 +1050,39 @@ h1 {
     white-space: pre;
 }
 
+.content blockquote {
+    margin: 0.6em 0;
+    padding: 0.1em 1em;
+    border-left: 3px solid var(--border);
+    background: #101535;
+    color: #c5cee0;
+}
+
+.content table {
+    border-collapse: collapse;
+    margin: 1em 0;
+    width: 100%;
+}
+
+.content th,
+.content td {
+    border: 1px solid var(--border);
+    padding: 0.4em 0.6em;
+}
+
+.content th {
+    background: #101535;
+    color: var(--neon-cyan);
+    text-align: left;
+}
+
+.content img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 0.6em auto;
+}
+
 footer {
     margin: 28px 0 8px;
     text-align: center;

--- a/generate_site.py
+++ b/generate_site.py
@@ -21,162 +21,8 @@ def write_file(path, content):
 
 
 def simple_markdown(md):
-    import re  # Import re module for regular expressions
-    lines = md.splitlines()
-    html_lines = []
-    in_code_block = False
-    code_lang = ''
-    list_stack = []
-    # 1단계=disc, 2단계=circle, 3단계=none(대시)
-    style_map = {1: 'disc', 2: 'circle', 3: 'none'}
-    code_lines = []  # To store lines within a code block
-    code_indents = []  # To store indentation levels of code lines
-
-    def process_inline(text):
-        code_spans = {}
-        def repl_code(m):
-            key = f"{{{{code{len(code_spans)}}}}}"
-            code_spans[key] = f"<code>{m.group(1)}</code>"
-            return key
-        text = re.sub(r'`([^`]+?)`', repl_code, text)
-        # 이미지
-        text = re.sub(
-            r'!\[([^\]]*?)\]\((\S+?)(?:\s+"(.*?)")?\)',
-            lambda m: (
-                f'<img src="{m.group(2)}" alt="{m.group(1)}"'
-                + (f' title="{m.group(3)}"' if m.group(3) else '')
-                + '>'
-            ),
-            text
-        )
-        # 링크: target="_blank" 추가
-        text = re.sub(
-            r'\[([^\]]+?)\]\((\S+?)(?:\s+"(.*?)")?\)',
-            lambda m: (
-                f'<a href="{m.group(2)}" target="_blank"'
-                + (f' title="{m.group(3)}"' if m.group(3) else '')
-                + f'>{m.group(1)}</a>'
-            ),
-            text
-        )
-        # 굵은 글씨
-        text = re.sub(r'(\*\*|__)(.+?)\1', r'<strong>\2</strong>', text)
-        # 기울임
-        text = re.sub(r'(\*|_)(.+?)\1', r'<em>\2</em>', text)
-        # 토큰 복원
-        for key, val in code_spans.items():
-            text = text.replace(key, val)
-        return text
-
-    for line in lines:
-        stripped = line.lstrip(' ')
-        leading = len(line) - len(stripped)  # Count each space as one indent
-
-        # 코드 블록 펜스 처리 (```lang)
-        m_fence = re.match(r'^(\s*)(```)(\w+)?\s*$', line)
-        if m_fence:
-            indent = len(m_fence.group(1))  # Count spaces for fence indent
-            if not in_code_block:
-                code_lang = m_fence.group(3) or 'unknown'
-                class_attr = f' class="code-block language-{code_lang}"'
-                data_attr = f' data-language="{code_lang.upper()}"'
-                html_lines.append(
-                    f'<div{class_attr}{data_attr} style="margin-left: {indent * 8}px">'
-                    f'<button class="copy-button">Copy</button>'
-                    f'<pre><code>'
-                )
-                in_code_block = True
-                code_lines = []
-                code_indents = []
-            else:
-                # 코드 블록 종료: 공통 들여쓰기 제거
-                if code_lines:
-                    min_indent = min(code_indents) if code_indents else 0
-                    for code_line in code_lines:
-                        if code_line.strip():  # 비어 있지 않은 줄만 처리
-                            html_lines.append(code_line[min_indent:])
-                        else:
-                            html_lines.append(code_line)
-                html_lines.append('</code></pre></div>')
-                in_code_block = False
-                code_lang = ''
-                code_lines = []
-                code_indents = []
-            continue
-
-        if in_code_block:
-            # 코드 블록 내부: 줄을 수집하고 들여쓰기 기록
-            code_lines.append(line)
-            if stripped:  # 비어 있지 않은 줄만 들여쓰기 계산
-                code_indents.append(len(line) - len(line.lstrip(' ')))
-            continue
-
-        # 헤더
-        m_h = re.match(r'^(#{1,6})\s+(.*)', stripped)
-        if m_h:
-            while list_stack:
-                html_lines.append('</ul>')
-                list_stack.pop()
-            level = len(m_h.group(1))
-            content = process_inline(m_h.group(2))
-            html_lines.append(f'<h{level}>{content}</h{level}>')
-            continue
-
-        # 리스트
-        m_list = re.match(r'^([-*])\s+(.*)', stripped)
-        if m_list:
-            marker, content_raw = m_list.groups()
-            content = process_inline(content_raw)
-            depth = len(list_stack) + 1 if not list_stack or leading > list_stack[-1] else len(list_stack)
-            # 새 리스트 시작
-            if not list_stack or leading > list_stack[-1]:
-                style = style_map.get(depth, 'disc')
-                html_lines.append(
-                    f'<ul style="margin-left: {leading*8}px; list-style-type: {style}">'
-                )
-                list_stack.append(leading)
-            else:
-                while list_stack and leading < list_stack[-1]:
-                    html_lines.append('</ul>')
-                    list_stack.pop()
-                style = style_map.get(depth, 'disc')
-            # 3단계(none)인 경우 항목 앞에 대시 추가
-            if style_map.get(depth) == 'none':
-                content = '- ' + content
-            html_lines.append(f'<li>{content}</li>')
-            continue
-
-        # 열린 리스트 닫기
-        if list_stack:
-            while list_stack:
-                html_lines.append('</ul>')
-                list_stack.pop()
-
-        # 단락
-        if stripped == '':
-            html_lines.append('')
-        else:
-            indent_html = ' ' * leading
-            content = process_inline(stripped)
-            html_lines.append(f'<p>{indent_html}{content}</p>')
-
-    # 마무리: 열린 코드 블록 및 리스트 닫기
-    if in_code_block:
-        if code_lines:
-            min_indent = min(code_indents) if code_indents else 0
-            for code_line in code_lines:
-                if code_line.strip():
-                    html_lines.append(code_line[min_indent:])
-                else:
-                    html_lines.append(code_line)
-        html_lines.append('</code></pre></div>')
-    if list_stack:
-        while list_stack:
-            html_lines.append('</ul>')
-            list_stack.pop()
-
-    return '\n'.join(html_lines)
-
+    """Markdown conversion removed."""
+    return md
 
 def render_template(template_name, **context):
     template_path = os.path.join(TEMPLATES_DIR, template_name)
@@ -240,7 +86,7 @@ def build_devlog(nav_links):
                     date_str = m.group(0)
                     body_lines.pop(i)
                     break
-            body = simple_markdown('\n'.join(body_lines))
+            body = '\n'.join(body_lines)
             rel_path = os.path.relpath(path, posts_dir)
             slug = os.path.splitext(rel_path)[0]
             content = render_template('post.html', title=title, date=date_str, body=body)
@@ -322,7 +168,7 @@ def build_portfolio(nav_links):
                 md = read_file(path)
                 title_line = md.splitlines()[0]
                 title = title_line.lstrip('#').strip()
-                body = simple_markdown('\n'.join(md.splitlines()[1:]))
+                body = '\n'.join(md.splitlines()[1:])
             elif ext == '.html':
                 html = read_file(path)
                 import re


### PR DESCRIPTION
## Summary
- Drop Python-based markdown conversion, leaving raw markdown for devlog and portfolio pages
- Expand style.css to cover blockquote, table, and image markdown elements

## Testing
- `python generate_site.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb70a58fb0832b9febf81669f2d401