### PR TITLE
Render devlog markdown

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Install dependencies
+        run: pip install markdown
+
       - name: Generate static site
         run: python generate_site.py
 

--- a/generate_site.py
+++ b/generate_site.py
@@ -1,6 +1,18 @@
 import os
 import re
 
+try:
+    import markdown
+except ImportError:
+    markdown = None
+
+
+def md_to_html(text: str) -> str:
+    """Convert markdown text to HTML."""
+    if markdown is None:
+        return text
+    return markdown.markdown(text, extensions=["fenced_code", "tables"])
+
 CONTENT_DIR = 'content'
 OUTPUT_DIR = 'docs'
 TEMPLATES_DIR = 'templates'
@@ -82,7 +94,7 @@ def build_devlog(nav_links):
                     date_str = m.group(0)
                     body_lines.pop(i)
                     break
-            body = '\n'.join(body_lines)
+            body = md_to_html('\n'.join(body_lines))
             rel_path = os.path.relpath(path, posts_dir)
             slug = os.path.splitext(rel_path)[0]
             content = render_template('post.html', title=title, date=date_str, body=body)
@@ -164,7 +176,7 @@ def build_portfolio(nav_links):
                 md = read_file(path)
                 title_line = md.splitlines()[0]
                 title = title_line.lstrip('#').strip()
-                body = '\n'.join(md.splitlines()[1:])
+                body = md_to_html('\n'.join(md.splitlines()[1:]))
             elif ext == '.html':
                 html = read_file(path)
                 import re


### PR DESCRIPTION
## Summary
- convert devlog and portfolio markdown into HTML using a markdown parser
- install markdown dependency in CI before generating the static site

## Testing
- `pip install markdown` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python generate_site.py`
- `python -m py_compile generate_site.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb79b8d95c832b86eb060de7892565