### PR TITLE
Handle horizontal rules and escape inline code in markdown parser

### DIFF
--- a/generate_site.py
+++ b/generate_site.py
@@ -35,7 +35,13 @@ def simple_markdown(md):
         code_spans = {}
         def repl_code(m):
             key = f"{{{{code{len(code_spans)}}}}}"
-            code_spans[key] = f"<code>{m.group(1)}</code>"
+            code_content = (
+                m.group(1)
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+            )
+            code_spans[key] = f"<code>{code_content}</code>"
             return key
         text = re.sub(r'`([^`]+?)`', repl_code, text)
         # 이미지
@@ -150,6 +156,11 @@ def simple_markdown(md):
             while list_stack:
                 html_lines.append('</ul>')
                 list_stack.pop()
+
+        # 수평선
+        if re.match(r'^-{3,}\s*$', stripped):
+            html_lines.append('<hr>')
+            continue
 
         # 단락
         if stripped == '':


### PR DESCRIPTION
## Summary
- Escape HTML characters inside inline code spans so constructs like `@text: <text>` render correctly
- Recognize lines of dashes as horizontal rules

## Testing
- `python -m py_compile generate_site.py`
- `python - <<'PY'
from generate_site import simple_markdown
print(simple_markdown("Test\n---\n`@text: <text>`"))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bb834db218832b8c331e9a778b98d5