### PR TITLE
feat: add copy buttons for inline code and unify hr style

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -122,6 +122,13 @@ a:hover::after {
     width: 100%;
 }
 
+hr {
+    border: none;
+    border-top: 1px solid rgba(0, 217, 255, 0.3);
+    margin: 2rem 0;
+    box-shadow: 0 0 10px rgba(0, 217, 255, 0.3);
+}
+
 /* 네비게이션 - 더 사이버펑크스러운 디자인 */
 nav {
     display: flex;
@@ -603,6 +610,42 @@ footer a:hover {
 }
 
 .code-block .copy-button:hover {
+    background: rgba(0, 217, 255, 0.1);
+    box-shadow: 0 0 10px rgba(0, 217, 255, 0.5);
+}
+
+.inline-code {
+    display: inline-block;
+    position: relative;
+    background: var(--bg-color, #0a0a0f);
+    border: 1px solid rgba(0, 217, 255, 0.3);
+    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
+    margin: 0 0.2rem;
+}
+
+.inline-code code {
+    color: var(--neon-cyan);
+    text-shadow: 0 0 5px rgba(0, 217, 255, 0.3);
+    padding-right: 1.5rem;
+}
+
+.inline-code .copy-button {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    background: var(--bg-color, #0a0a0f);
+    color: var(--neon-cyan, #00d9ff);
+    border: 1px solid rgba(0, 217, 255, 0.3);
+    border-radius: 4px;
+    padding: 0.1rem 0.3rem;
+    font-size: 0.6rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-shadow: 0 0 5px rgba(0, 217, 255, 0.3);
+}
+
+.inline-code .copy-button:hover {
     background: rgba(0, 217, 255, 0.1);
     box-shadow: 0 0 10px rgba(0, 217, 255, 0.5);
 }

--- a/generate_site.py
+++ b/generate_site.py
@@ -41,7 +41,12 @@ def simple_markdown(md):
                 .replace("<", "&lt;")
                 .replace(">", "&gt;")
             )
-            code_spans[key] = f"<code>{code_content}</code>"
+            code_spans[key] = (
+                "<span class=\"inline-code\">"
+                "<button class=\"copy-button\">Copy</button>"
+                f"<code>{code_content}</code>"
+                "</span>"
+            )
             return key
         text = re.sub(r'`([^`]+?)`', repl_code, text)
         # 이미지

--- a/templates/base.html
+++ b/templates/base.html
@@ -160,7 +160,8 @@
 
         document.querySelectorAll('.copy-button').forEach(button => {
             button.addEventListener('click', () => {
-                const codeElement = button.closest('.code-block').querySelector('code');
+                const container = button.closest('.code-block, .inline-code');
+                const codeElement = container.querySelector('code');
                 const text = codeElement.innerText;
                 navigator.clipboard.writeText(text).then(() => {
                     button.textContent = 'Copied!';


### PR DESCRIPTION
## Summary
- unify `<hr>` element with neon-themed styling
- enable copy buttons on inline code snippets
- support inline copy buttons through client script

## Testing
- `python -m py_compile generate_site.py`
- `python generate_site.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb870f0d2c832bb4b8ea3a77587dd0