### PR TITLE
Remove copy button for inline code blocks

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -627,27 +627,6 @@ footer a:hover {
 .inline-code code {
     color: var(--neon-cyan);
     text-shadow: 0 0 5px rgba(0, 217, 255, 0.3);
-    padding-right: 1.5rem;
-}
-
-.inline-code .copy-button {
-    position: absolute;
-    top: 2px;
-    right: 2px;
-    background: var(--bg-color, #0a0a0f);
-    color: var(--neon-cyan, #00d9ff);
-    border: 1px solid rgba(0, 217, 255, 0.3);
-    border-radius: 4px;
-    padding: 0.1rem 0.3rem;
-    font-size: 0.6rem;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    text-shadow: 0 0 5px rgba(0, 217, 255, 0.3);
-}
-
-.inline-code .copy-button:hover {
-    background: rgba(0, 217, 255, 0.1);
-    box-shadow: 0 0 10px rgba(0, 217, 255, 0.5);
 }
 
 /* Language-specific classes */

--- a/generate_site.py
+++ b/generate_site.py
@@ -43,7 +43,6 @@ def simple_markdown(md):
             )
             code_spans[key] = (
                 "<span class=\"inline-code\">"
-                "<button class=\"copy-button\">Copy</button>"
                 f"<code>{code_content}</code>"
                 "</span>"
             )


### PR DESCRIPTION
## Summary
- Avoid adding copy button when rendering inline code
- Clean up CSS now that inline code lacks a copy button

## Testing
- `python -m py_compile generate_site.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb884bf52c832b9d790a739acbfba5